### PR TITLE
attribute value check

### DIFF
--- a/src/Controllers/AttributeController.php
+++ b/src/Controllers/AttributeController.php
@@ -55,7 +55,7 @@ class AttributeController extends Controller
         $categories = $settingsHelper->get(SettingsHelper::CATEGORIES_LIST);
 
         if(isset($categories[$categoryId])) {
-            if(isset($attributes[$categoryId])) {
+            if(isset($attributes[$categoryId]) && ($attributes[$categoryId] !== null)) {
                 return $attributes[$categoryId];
             } else {
                 $attributes[$categoryId] = $pbApiHelper->fetchPBAttributes($categoryId);


### PR DESCRIPTION
There could be situations where API responds null. so to overcome this, we would like to have a check before responding the data with existing information.

